### PR TITLE
pg_dumpのオプションに-Fcを追加 & --cleanを削除

### DIFF
--- a/remote-bastion-dump-eb-pg
+++ b/remote-bastion-dump-eb-pg
@@ -18,7 +18,7 @@ echo "IP: ${ip}"
 ssh -f -N -L 15432:${db_host}:5432 -i ${pempath} ec2-user@${ip}
 echo 'connected'
 
-pg_dump --clean -h localhost -p 15432  -U ${db_user} ${pg_dump_params} ${db_name} > ${beanstalkenv}`date "+%Y%m%d_%H%M%S"`.sql
+pg_dump -Fc -h localhost -p 15432  -U ${db_user} ${pg_dump_params} ${db_name} > ${beanstalkenv}`date "+%Y%m%d_%H%M%S"`.sql
 echo 'dumped'
 
 ps aux | grep "ssh -f -N -L" | grep ${ip} | awk '{ print $2 }'  | xargs kill -9


### PR DESCRIPTION
参照記事は以下です。
https://www.postgresql.jp/document/9.2/html/app-pgdump.html

-Fcコマンドを付けたのはダンプしたファイルでpg_restoreをできるようにするためです。

--cleanオプションを消したのは、このオプションは平文形式の時に有効なので、-Fcコマンドでカスタム形式では意味がないためです。
代わりにpg_restoreを実行する時に--cleanオプションを付けてあげる形になります。

> このオプションは平文形式の場合にのみ有効です。 アーカイブ形式では、pg_restoreを呼び出す時にこのオプションを指定することができます。