### PR TITLE
Improve aws-mfa.sh duration handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ set AWS_MFA_SERIAL in your environment as your MFA Device(ex. in ~/.bash_profile
 
 ```
 export AWS_MFA_SERIAL=arn:aws:iam::111122223333:mfa/your-iam-user
-source aws-mfa.sh
+source aws-mfa.sh [duration-seconds]
 ```
+
+If duration-seconds is not specified, AWS default (12 hours) will be used.
 
 ## switch-role-with-mfa.sh
 switch role with MFA.

--- a/aws-mfa.sh
+++ b/aws-mfa.sh
@@ -18,21 +18,21 @@ read -p "Enter MFA code (6 digits): " MFA_CODE
 
 echo "🔐 Getting session token using MFA..."
 
-# Build command
-STS_CMD="aws sts get-session-token \
-  --serial-number \"$AWS_MFA_SERIAL\" \
-  --token-code \"$MFA_CODE\" \
-  --profile \"$AWS_SOURCE_PROFILE\""
+# Build command arguments array
+AWS_CMD_ARGS=(sts get-session-token
+  --serial-number "$AWS_MFA_SERIAL"
+  --token-code "$MFA_CODE"
+  --profile "$AWS_SOURCE_PROFILE")
 
 # Add duration only if specified
 if [[ -n "$DURATION_SECONDS" ]]; then
-  STS_CMD="$STS_CMD --duration-seconds $DURATION_SECONDS"
+  AWS_CMD_ARGS+=(--duration-seconds "$DURATION_SECONDS")
   echo "⏱️  Using custom duration: ${DURATION_SECONDS} seconds"
 fi
 
-STS_CMD="$STS_CMD --output json 2>&1"
+AWS_CMD_ARGS+=(--output json)
 
-SESSION_JSON=$(eval "$STS_CMD") || {
+SESSION_JSON=$(aws "${AWS_CMD_ARGS[@]}" 2>&1) || {
   echo "❌ Failed to get session token."
   echo "$SESSION_JSON"
   return 1

--- a/aws-mfa.sh
+++ b/aws-mfa.sh
@@ -8,18 +8,31 @@ if [[ -z "${AWS_MFA_SERIAL:-}" ]]; then
   return 1
 fi
 
+# Duration parameter (optional)
+DURATION_SECONDS="${1:-}"
+
 AWS_SOURCE_PROFILE="${AWS_SOURCE_PROFILE:-${AWS_PROFILE:-default}}"
 echo "🔑 Using source profile: $AWS_SOURCE_PROFILE"
 
 read -p "Enter MFA code (6 digits): " MFA_CODE
 
 echo "🔐 Getting session token using MFA..."
-SESSION_JSON=$(aws sts get-session-token \
-  --serial-number "$AWS_MFA_SERIAL" \
-  --token-code "$MFA_CODE" \
-  --profile "$AWS_SOURCE_PROFILE" \
-  --duration-seconds 129600 \
-  --output json 2>&1) || {
+
+# Build command
+STS_CMD="aws sts get-session-token \
+  --serial-number \"$AWS_MFA_SERIAL\" \
+  --token-code \"$MFA_CODE\" \
+  --profile \"$AWS_SOURCE_PROFILE\""
+
+# Add duration only if specified
+if [[ -n "$DURATION_SECONDS" ]]; then
+  STS_CMD="$STS_CMD --duration-seconds $DURATION_SECONDS"
+  echo "⏱️  Using custom duration: ${DURATION_SECONDS} seconds"
+fi
+
+STS_CMD="$STS_CMD --output json 2>&1"
+
+SESSION_JSON=$(eval "$STS_CMD") || {
   echo "❌ Failed to get session token."
   echo "$SESSION_JSON"
   return 1

--- a/aws-mfa.sh
+++ b/aws-mfa.sh
@@ -19,18 +19,18 @@ read -p "Enter MFA code (6 digits): " MFA_CODE
 echo "🔐 Getting session token using MFA..."
 
 # Build command arguments array
-AWS_CMD_ARGS=(sts get-session-token
-  --serial-number "$AWS_MFA_SERIAL"
-  --token-code "$MFA_CODE"
-  --profile "$AWS_SOURCE_PROFILE")
+AWS_CMD_ARGS=('sts' 'get-session-token'
+  '--serial-number' "$AWS_MFA_SERIAL"
+  '--token-code' "$MFA_CODE"
+  '--profile' "$AWS_SOURCE_PROFILE")
 
 # Add duration only if specified
 if [[ -n "$DURATION_SECONDS" ]]; then
-  AWS_CMD_ARGS+=(--duration-seconds "$DURATION_SECONDS")
+  AWS_CMD_ARGS+=('--duration-seconds' "$DURATION_SECONDS")
   echo "⏱️  Using custom duration: ${DURATION_SECONDS} seconds"
 fi
 
-AWS_CMD_ARGS+=(--output json)
+AWS_CMD_ARGS+=('--output' 'json')
 
 SESSION_JSON=$(aws "${AWS_CMD_ARGS[@]}" 2>&1) || {
   echo "❌ Failed to get session token."


### PR DESCRIPTION
## Summary
- Remove hardcoded 36-hour duration from aws-mfa.sh
- Use AWS default duration (12 hours) when no parameter specified  
- Add optional duration-seconds parameter for custom durations
- Update README.md with new usage instructions

## Problem
The current implementation hardcodes a 36-hour session duration, which can cause authentication failures if the IAM user's maximum session duration is set lower than 36 hours.

## Solution
- Default to AWS's standard behavior (12 hours) when no duration is specified
- Allow users to optionally specify custom duration as a parameter
- This provides safety by default while maintaining flexibility

## Test plan
- [x] Verify script accepts optional duration parameter
- [x] Confirm default behavior uses AWS standard duration
- [x] Update documentation reflects new usage

🤖 Generated with [Claude Code](https://claude.ai/code)