### PR TITLE
Show worktree list before menu in git-wt interactive mode

### DIFF
--- a/git-wt
+++ b/git-wt
@@ -180,6 +180,9 @@ case "$command" in
     ;;
   "")
     # No arguments: show selection menu
+    echo "📋 Current worktrees:"
+    git worktree list
+    echo ""
     echo "Please select a command:"
     echo "a. add - Create new worktree"
     echo "p. pop - Remove existing worktree"


### PR DESCRIPTION
## Summary
- Display current worktrees when `git-wt` is launched without arguments
- Shows the list before the interactive menu appears
- Makes it easier to see existing worktrees before choosing an action

## Test plan
- [ ] Run `git-wt` without arguments
- [ ] Verify that worktree list appears before the menu
- [ ] Confirm menu still works as expected (add/pop/help/quit)

🤖 Generated with [Claude Code](https://claude.ai/code)