### PR TITLE
Add file copy feature to git-wt worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ git-wt pop 2
 git-wt
 ```
 
+### File Copy Configuration
+Create a `.git-wt.conf` file in your repository root to automatically copy specific files and directories from the main branch to new worktrees:
+
+```
+# .git-wt.conf
+README.md
+config/database.yml.example
+.env.example
+config/templates
+node_modules
+# Comments are supported
+```
+
+Files and directories listed in this configuration will be copied from the main branch to each new worktree, preserving directory structure. Missing files/directories are skipped with a warning message.
+
 ## git-remove-merged-branches
 Remove merged branches in current git directory.
 

--- a/git-wt
+++ b/git-wt
@@ -152,27 +152,67 @@ cleanup_worktrees_dir() {
   return 0
 }
 
+# Copy files from main branch to worktree based on .git-wt.conf
+copy_files_to_worktree() {
+  local target="$1"
+  local config_file="$root/.git-wt.conf"
+
+  # Skip if config file doesn't exist
+  [[ -f "$config_file" ]] || return 0
+
+  local copied_count=0
+
+  # Read each line from config file
+  while IFS= read -r file_path || [[ -n "$file_path" ]]; do
+    # Skip empty lines and comments
+    [[ -z "$file_path" || "$file_path" =~ ^[[:space:]]*# ]] && continue
+
+    # Trim whitespace
+    file_path="${file_path#"${file_path%%[![:space:]]*}"}"
+    file_path="${file_path%"${file_path##*[![:space:]]}"}"
+
+    [[ -z "$file_path" ]] && continue
+
+    # Check if source file exists
+    if [[ -f "$root/$file_path" ]]; then
+      # Create directory structure in target
+      mkdir -p "$target/$(dirname "$file_path")"
+
+      # Copy file
+      cp "$root/$file_path" "$target/$file_path"
+      echo "📄 Copied: $file_path"
+      copied_count=$((copied_count + 1))
+    else
+      echo "⚠️ Warning: File not found, skipping: $file_path" >&2
+    fi
+  done < "$config_file"
+
+  if [[ $copied_count -gt 0 ]]; then
+    echo "✅ Copied $copied_count files from configuration"
+  fi
+}
+
 # Create new worktree with given branch name
 create_worktree() {
   local branch="$1"
-  
+
   # Sanitize branch name
   sanitize_branch_name "$branch"
-  
+
   # Find next available number (maximum 9)
   local next_num=1
   while [[ $next_num -le 9 && -e "$wroot/$next_num" ]]; do
     ((next_num++))
   done
-  
+
   if [[ $next_num -gt 9 ]]; then
     echo "❌ Maximum 9 worktrees allowed. Please remove one first with: git-wt pop" >&2
     exit 1
   fi
-  
+
   local target="$wroot/$next_num"
   mkdir -p "$wroot"
-  
+
   # Track if branch exists remotely, otherwise create new
   if git show-ref --verify --quiet "refs/heads/$branch"; then
     git worktree add "$target" "$branch" || { rmdir "$target" 2>/dev/null; exit 1; }
@@ -181,10 +221,14 @@ create_worktree() {
   else
     git worktree add -b "$branch" "$target" || { rmdir "$target" 2>/dev/null; exit 1; }
   fi
-  
+
   echo "✅ Worktree created: $target (branch: $branch)"
+
+  # Copy files from configuration
+  copy_files_to_worktree "$target"
+
   git worktree list
-  
+
   # Show command to navigate to new directory
   echo ""
   echo "📁 To navigate to the new directory:"

--- a/git-wt
+++ b/git-wt
@@ -173,17 +173,25 @@ copy_files_to_worktree() {
 
     [[ -z "$file_path" ]] && continue
 
-    # Check if source file exists
+    # Check if source file or directory exists
     if [[ -f "$root/$file_path" ]]; then
       # Create directory structure in target
       mkdir -p "$target/$(dirname "$file_path")"
 
       # Copy file
       cp "$root/$file_path" "$target/$file_path"
-      echo "📄 Copied: $file_path"
+      echo "📄 Copied file: $file_path"
+      copied_count=$((copied_count + 1))
+    elif [[ -d "$root/$file_path" ]]; then
+      # Create parent directory structure in target
+      mkdir -p "$target/$(dirname "$file_path")"
+
+      # Copy directory recursively
+      cp -r "$root/$file_path" "$target/$file_path"
+      echo "📁 Copied directory: $file_path"
       copied_count=$((copied_count + 1))
     else
-      echo "⚠️ Warning: File not found, skipping: $file_path" >&2
+      echo "⚠️ Warning: File or directory not found, skipping: $file_path" >&2
     fi
   done < "$config_file"
 


### PR DESCRIPTION
## Summary
- Add automatic file copying from main branch to new worktrees
- Simple `.git-wt.conf` configuration file format
- Preserve directory structure and handle missing files gracefully

## Features
- **Configuration file**: `.git-wt.conf` in repository root
- **Simple format**: One file path per line, supports comments with `#`
- **Safe handling**: Skip missing files with warning, preserve directory structure
- **Zero config**: Works without configuration file (no copying)

## Example Configuration
```
# .git-wt.conf
README.md
config/database.yml.example
.env.example
# Comments are supported
```

## Test plan
- [x] Test with configuration file present
- [x] Test with missing configuration file
- [x] Test with missing files in configuration
- [x] Test directory structure preservation
- [x] Test comment handling in configuration

🤖 Generated with [Claude Code](https://claude.ai/code)