### PR TITLE
Improve worktree creation message to show branch type

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ source ~/.bashrc  # or ~/.zshrc
 Manage Git worktrees with sequential numbering in `../<repo>.worktrees/<number>` directories.
 
 ```bash
-# Create worktree with branch
+# Create worktree with new branch
 git-wt add feature-branch
+
+# Or use existing branch (local or remote)
+git-wt add existing-branch
 
 # Remove highest numbered worktree
 git-wt pop

--- a/git-wt
+++ b/git-wt
@@ -372,13 +372,14 @@ create_worktree() {
   # Track if branch exists remotely, otherwise create new
   if git show-ref --verify --quiet "refs/heads/$branch"; then
     git worktree add "$target" "$branch" || { rmdir "$target" 2>/dev/null; exit 1; }
+    echo "✅ Worktree created: $target (existing branch: $branch)"
   elif git ls-remote --exit-code --heads origin "$branch" &>/dev/null; then
     git worktree add "$target" "origin/$branch" || { rmdir "$target" 2>/dev/null; exit 1; }
+    echo "✅ Worktree created: $target (remote branch: $branch)"
   else
     git worktree add -b "$branch" "$target" || { rmdir "$target" 2>/dev/null; exit 1; }
+    echo "✅ Worktree created: $target (new branch: $branch)"
   fi
-
-  echo "✅ Worktree created: $target (branch: $branch)"
 
   # Copy files from configuration
   copy_files_to_worktree "$target" "$next_num" "$branch"


### PR DESCRIPTION
## Summary
- Improve worktree creation message to indicate branch type
- `existing branch`: Uses an existing local branch
- `remote branch`: Tracks a remote branch
- `new branch`: Creates a new branch

## Test plan
- [ ] `git-wt add <new-branch>` shows "new branch"
- [ ] `git-wt add <existing-local-branch>` shows "existing branch"
- [ ] `git-wt add <remote-only-branch>` shows "remote branch"

🤖 Generated with [Claude Code](https://claude.com/claude-code)