### PR TITLE
Add status tracking and Web UI for git-wt

### DIFF
--- a/git-wt
+++ b/git-wt
@@ -10,6 +10,8 @@ Commands:
   git-wt add <branch>  Create worktree with branch
   git-wt pop [num]     Remove worktree by number (defaults to highest)
   git-wt goto <num>    Copy cd command to clipboard (0=main, 1-9=worktree)
+  git-wt task [desc]   Set/show task description for current worktree
+  git-wt status [-w]   Show status of all worktrees (-w: watch mode)
   git-wt               Show interactive menu
 
 Examples:
@@ -18,6 +20,10 @@ Examples:
   git-wt pop 2          Remove worktree directory "2"
   git-wt goto 0         Copy cd command to main repository
   git-wt goto 1         Copy cd command to worktree 1
+  git-wt task "認証機能実装"  Set task description
+  git-wt status         Show all worktrees with their tasks
+  git-wt status -w      Watch mode (auto-refresh every 2s)
+  git-wt status -w -n 5 Watch mode with 5s interval
   git-wt                Interactive menu with add/pop/help/exit options
 EOF
   exit 1
@@ -140,6 +146,8 @@ cleanup_worktrees_dir() {
     has_anything=true
 
     local basename_item=$(basename "$item")
+    # Skip .status directory (managed by git-wt)
+    [[ "$basename_item" == ".status" ]] && continue
     if [[ ! "$basename_item" =~ ^[1-9]$ ]] || [[ ! -d "$item" ]]; then
       has_non_numbered=true
       non_numbered_items+=("$basename_item")
@@ -268,6 +276,424 @@ get_remote_repo_path() {
   else
     return 1
   fi
+}
+
+# ─────────────────────────────────────────────────────────────
+# Status management functions
+# ─────────────────────────────────────────────────────────────
+
+# Get status directory path
+get_status_dir() {
+  echo "$wroot/.status"
+}
+
+# Get current worktree number from PWD
+# Returns: worktree number (1-9) or empty if not in a worktree
+get_current_worktree_num() {
+  local current_path="$PWD"
+
+  # Check if current path matches .worktrees/<num> pattern
+  if [[ "$current_path" =~ \.worktrees/([1-9])(/|$) ]]; then
+    echo "${BASH_REMATCH[1]}"
+  fi
+}
+
+# Get worktree number from path
+get_worktree_num_from_path() {
+  local path="$1"
+  if [[ "$path" =~ \.worktrees/([1-9])(/|$) ]]; then
+    echo "${BASH_REMATCH[1]}"
+  fi
+}
+
+# Set task for a worktree
+# Usage: set_worktree_task <num> <description>
+set_worktree_task() {
+  local num="$1"
+  local description="$2"
+  local status_dir
+  status_dir=$(get_status_dir)
+
+  mkdir -p "$status_dir"
+
+  local status_file="$status_dir/${num}.json"
+  local timestamp
+  timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+
+  # Get branch name for this worktree
+  local branch=""
+  local worktree_path="$wroot/$num"
+  if [[ -d "$worktree_path" ]]; then
+    branch=$(git -C "$worktree_path" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  fi
+
+  # Check if status file already exists (preserve first_task)
+  if [[ -f "$status_file" ]]; then
+    # Update last_task, status, and timestamp only
+    local first_task
+    first_task=$(grep -o '"first_task": *"[^"]*"' "$status_file" | sed 's/"first_task": *"\(.*\)"/\1/' || echo "")
+
+    # If first_task is empty (old format), use current task as first_task
+    [[ -z "$first_task" ]] && first_task=$(grep -o '"task": *"[^"]*"' "$status_file" | sed 's/"task": *"\(.*\)"/\1/' || echo "$description")
+
+    cat > "$status_file" << EOF
+{
+  "first_task": "$first_task",
+  "last_task": "$description",
+  "status": "active",
+  "branch": "$branch",
+  "updated": "$timestamp"
+}
+EOF
+  else
+    # New file: set both first_task and last_task
+    cat > "$status_file" << EOF
+{
+  "first_task": "$description",
+  "last_task": "$description",
+  "status": "active",
+  "branch": "$branch",
+  "updated": "$timestamp"
+}
+EOF
+  fi
+}
+
+# Get first task for a worktree
+get_worktree_first_task() {
+  local num="$1"
+  local status_dir
+  status_dir=$(get_status_dir)
+  local status_file="$status_dir/${num}.json"
+
+  if [[ -f "$status_file" ]]; then
+    local first_task
+    first_task=$(grep -o '"first_task": *"[^"]*"' "$status_file" | sed 's/"first_task": *"\(.*\)"/\1/')
+    # Fallback to old format
+    [[ -z "$first_task" ]] && first_task=$(grep -o '"task": *"[^"]*"' "$status_file" | sed 's/"task": *"\(.*\)"/\1/')
+    echo "$first_task"
+  fi
+}
+
+# Get last task for a worktree
+get_worktree_last_task() {
+  local num="$1"
+  local status_dir
+  status_dir=$(get_status_dir)
+  local status_file="$status_dir/${num}.json"
+
+  if [[ -f "$status_file" ]]; then
+    local last_task
+    last_task=$(grep -o '"last_task": *"[^"]*"' "$status_file" | sed 's/"last_task": *"\(.*\)"/\1/')
+    # Fallback to old format
+    [[ -z "$last_task" ]] && last_task=$(grep -o '"task": *"[^"]*"' "$status_file" | sed 's/"task": *"\(.*\)"/\1/')
+    echo "$last_task"
+  fi
+}
+
+# Get task for a worktree (backward compatibility - returns last_task)
+get_worktree_task() {
+  get_worktree_last_task "$1"
+}
+
+# Get status for a worktree
+get_worktree_status() {
+  local num="$1"
+  local status_dir
+  status_dir=$(get_status_dir)
+  local status_file="$status_dir/${num}.json"
+
+  if [[ -f "$status_file" ]]; then
+    grep -o '"status": *"[^"]*"' "$status_file" | sed 's/"status": *"\(.*\)"/\1/'
+  fi
+}
+
+# Get updated timestamp for a worktree
+get_worktree_updated() {
+  local num="$1"
+  local status_dir
+  status_dir=$(get_status_dir)
+  local status_file="$status_dir/${num}.json"
+
+  if [[ -f "$status_file" ]]; then
+    grep -o '"updated": *"[^"]*"' "$status_file" | sed 's/"updated": *"\(.*\)"/\1/'
+  fi
+}
+
+# Format relative time from local timestamp
+format_relative_time() {
+  local timestamp="$1"
+
+  # Convert timestamp to epoch seconds
+  local then_epoch
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    then_epoch=$(date -j -f "%Y-%m-%d %H:%M:%S" "$timestamp" +%s 2>/dev/null) || return
+  else
+    then_epoch=$(date -d "$timestamp" +%s 2>/dev/null) || return
+  fi
+
+  local now_epoch
+  now_epoch=$(date +%s)
+  local diff=$((now_epoch - then_epoch))
+
+  if [[ $diff -lt 60 ]]; then
+    echo "now"
+  elif [[ $diff -lt 3600 ]]; then
+    echo "$((diff / 60))分前"
+  elif [[ $diff -lt 86400 ]]; then
+    echo "$((diff / 3600))時間前"
+  else
+    echo "$((diff / 86400))日前"
+  fi
+}
+
+# Mark task as done
+mark_worktree_done() {
+  local num="$1"
+  local status_dir
+  status_dir=$(get_status_dir)
+  local status_file="$status_dir/${num}.json"
+
+  if [[ -f "$status_file" ]]; then
+    local timestamp
+    timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+
+    # Update status to done
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      sed -i '' "s/\"status\": *\"[^\"]*\"/\"status\": \"done\"/" "$status_file"
+      sed -i '' "s/\"updated\": *\"[^\"]*\"/\"updated\": \"$timestamp\"/" "$status_file"
+    else
+      sed -i "s/\"status\": *\"[^\"]*\"/\"status\": \"done\"/" "$status_file"
+      sed -i "s/\"updated\": *\"[^\"]*\"/\"updated\": \"$timestamp\"/" "$status_file"
+    fi
+    return 0
+  fi
+  return 1
+}
+
+# Mark task as asking (waiting for user selection)
+mark_worktree_asking() {
+  local num="$1"
+  local status_dir
+  status_dir=$(get_status_dir)
+  local status_file="$status_dir/${num}.json"
+
+  if [[ -f "$status_file" ]]; then
+    local timestamp
+    timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      sed -i '' "s/\"status\": *\"[^\"]*\"/\"status\": \"asking\"/" "$status_file"
+      sed -i '' "s/\"updated\": *\"[^\"]*\"/\"updated\": \"$timestamp\"/" "$status_file"
+    else
+      sed -i "s/\"status\": *\"[^\"]*\"/\"status\": \"asking\"/" "$status_file"
+      sed -i "s/\"updated\": *\"[^\"]*\"/\"updated\": \"$timestamp\"/" "$status_file"
+    fi
+    return 0
+  else
+    mkdir -p "$status_dir"
+    local timestamp
+    timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+    cat > "$status_file" << EOF
+{
+  "task": "",
+  "status": "asking",
+  "branch": "",
+  "updated": "$timestamp"
+}
+EOF
+    return 0
+  fi
+  return 1
+}
+
+# Mark task as waiting for input
+mark_worktree_waiting() {
+  local num="$1"
+  local status_dir
+  status_dir=$(get_status_dir)
+  local status_file="$status_dir/${num}.json"
+
+  if [[ -f "$status_file" ]]; then
+    local timestamp
+    timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+
+    # Update status to waiting
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      sed -i '' "s/\"status\": *\"[^\"]*\"/\"status\": \"waiting\"/" "$status_file"
+      sed -i '' "s/\"updated\": *\"[^\"]*\"/\"updated\": \"$timestamp\"/" "$status_file"
+    else
+      sed -i "s/\"status\": *\"[^\"]*\"/\"status\": \"waiting\"/" "$status_file"
+      sed -i "s/\"updated\": *\"[^\"]*\"/\"updated\": \"$timestamp\"/" "$status_file"
+    fi
+    return 0
+  else
+    # Create new status file with waiting status
+    mkdir -p "$status_dir"
+    local timestamp
+    timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+    cat > "$status_file" << EOF
+{
+  "task": "",
+  "status": "waiting",
+  "branch": "",
+  "updated": "$timestamp"
+}
+EOF
+    return 0
+  fi
+  return 1
+}
+
+# Clear task (remove status file)
+clear_worktree_task() {
+  local num="$1"
+  local status_dir
+  status_dir=$(get_status_dir)
+  local status_file="$status_dir/${num}.json"
+
+  if [[ -f "$status_file" ]]; then
+    rm "$status_file"
+  fi
+}
+
+# Set Claude's last message for a worktree
+set_worktree_claude_msg() {
+  local num="$1"
+  local message="$2"
+  local status_dir
+  status_dir=$(get_status_dir)
+  local status_file="$status_dir/${num}.json"
+
+  if [[ -f "$status_file" ]]; then
+    # Escape special characters for JSON
+    message="${message//\\/\\\\}"
+    message="${message//\"/\\\"}"
+    message="${message//$'\n'/\\n}"
+
+    # Check if claude_msg field exists
+    if grep -q '"claude_msg"' "$status_file" 2>/dev/null; then
+      # Update existing field
+      if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' "s/\"claude_msg\": *\"[^\"]*\"/\"claude_msg\": \"$message\"/" "$status_file"
+      else
+        sed -i "s/\"claude_msg\": *\"[^\"]*\"/\"claude_msg\": \"$message\"/" "$status_file"
+      fi
+    else
+      # Add new field before the closing brace
+      if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' "s/}$/,\n  \"claude_msg\": \"$message\"\n}/" "$status_file"
+      else
+        sed -i "s/}$/,\n  \"claude_msg\": \"$message\"\n}/" "$status_file"
+      fi
+    fi
+  fi
+}
+
+# Get Claude's last message for a worktree
+get_worktree_claude_msg() {
+  local num="$1"
+  local status_dir
+  status_dir=$(get_status_dir)
+  local status_file="$status_dir/${num}.json"
+
+  if [[ -f "$status_file" ]]; then
+    grep -o '"claude_msg": *"[^"]*"' "$status_file" 2>/dev/null | sed 's/"claude_msg": *"\(.*\)"/\1/' || true
+  fi
+}
+
+# Show status of all worktrees
+show_all_status() {
+  echo "git-wt ステータス ($repo)"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+  local has_worktrees=false
+
+  # Show main repo (0)
+  local main_branch
+  main_branch=$(git -C "$root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "-")
+  echo ""
+  echo "[0] $main_branch (main)"
+
+  # Show worktrees 1-9
+  for num in 1 2 3 4 5 6 7 8 9; do
+    local worktree_path="$wroot/$num"
+    [[ -d "$worktree_path" ]] || continue
+
+    has_worktrees=true
+
+    local branch
+    branch=$(git -C "$worktree_path" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "-")
+
+    local first_task
+    first_task=$(get_worktree_first_task "$num")
+
+    local last_task
+    last_task=$(get_worktree_last_task "$num")
+
+    local status
+    status=$(get_worktree_status "$num")
+
+    local updated
+    updated=$(get_worktree_updated "$num")
+    local relative_time=""
+    if [[ -n "$updated" ]]; then
+      relative_time=$(format_relative_time "$updated") || relative_time=""
+    fi
+
+    # Build header line: [num] branch (time)
+    echo ""
+    if [[ -n "$relative_time" ]]; then
+      echo "[$num] $branch ($relative_time)"
+    else
+      echo "[$num] $branch"
+    fi
+
+    # Show status indicator
+    local status_icon=""
+    case "$status" in
+      asking)  status_icon="🙋 選択待ち" ;;
+      waiting) status_icon="⏳ 入力待ち" ;;
+      active)  status_icon="● 作業中" ;;
+      done)    status_icon="✓ 完了" ;;
+    esac
+
+    if [[ -n "$status_icon" ]]; then
+      echo "    $status_icon"
+    fi
+
+    # Show first task (full)
+    if [[ -n "$first_task" ]]; then
+      echo "    📋 $first_task"
+    fi
+
+    # Show last task (truncated) if different from first
+    if [[ -n "$last_task" && "$last_task" != "$first_task" ]]; then
+      # Truncate to ~60 chars
+      local truncated_last="${last_task:0:60}"
+      [[ ${#last_task} -gt 60 ]] && truncated_last="${truncated_last}..."
+      echo "    └─ $truncated_last"
+    fi
+
+    # Show Claude's last message
+    local claude_msg
+    claude_msg=$(get_worktree_claude_msg "$num")
+    if [[ -n "$claude_msg" ]]; then
+      echo "    🤖 $claude_msg"
+    fi
+
+    # If no tasks at all
+    if [[ -z "$first_task" && -z "$last_task" && -z "$claude_msg" ]]; then
+      echo "    (タスクなし)"
+    fi
+  done
+
+  if [[ "$has_worktrees" == false ]]; then
+    echo ""
+    echo "(ワークツリーなし)"
+  fi
+
+  echo ""
 }
 
 # Find templates directory (repo-local or global)
@@ -459,7 +885,10 @@ case "$command" in
       git worktree remove --force "$target"
     fi
     echo "✅ Worktree removed: $target"
-    
+
+    # Remove status file for this worktree
+    clear_worktree_task "$target_num"
+
     # Safely cleanup worktrees directory
     cleanup_worktrees_dir
     
@@ -495,6 +924,113 @@ case "$command" in
         exit 1
       fi
       copy_cd_command "$target"
+    fi
+    ;;
+  task)
+    shift
+    # task subcommand processing
+    task_desc="${1-}"
+
+    # Get current worktree number
+    wt_num=$(get_current_worktree_num)
+
+    if [[ -z "$wt_num" ]]; then
+      echo "❌ Not in a git-wt managed worktree"
+      echo "   Current directory must be inside: <repo>.worktrees/<num>"
+      exit 1
+    fi
+
+    if [[ -z "$task_desc" ]]; then
+      # Show current task
+      current_task=$(get_worktree_task "$wt_num")
+      if [[ -n "$current_task" ]]; then
+        echo "📋 Worktree $wt_num: $current_task"
+      else
+        echo "📋 Worktree $wt_num: (no task set)"
+      fi
+    else
+      # Set task
+      set_worktree_task "$wt_num" "$task_desc"
+      echo "✅ Task set for worktree $wt_num: $task_desc"
+    fi
+    ;;
+  status)
+    shift
+    # status subcommand processing
+    watch_mode=false
+    watch_interval=2
+
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -w|--watch)
+          watch_mode=true
+          shift
+          ;;
+        -n|--interval)
+          watch_interval="$2"
+          shift 2
+          ;;
+        *)
+          echo "❌ Unknown option: $1"
+          exit 1
+          ;;
+      esac
+    done
+
+    if [[ "$watch_mode" == true ]]; then
+      # Watch mode: refresh every N seconds
+      trap 'printf "\033[?25h"; echo ""; echo "👋 Stopped watching"; exit 0' INT
+      printf "\033[?25l"  # Hide cursor
+      while true; do
+        # Move cursor to top and clear screen
+        printf "\033[H\033[J"
+        echo "👀 git-wt status --watch (Ctrl+C to stop)"
+        echo ""
+        show_all_status
+        echo ""
+        echo "🕐 Updated: $(date '+%H:%M:%S') (interval: ${watch_interval}s)"
+        sleep "$watch_interval"
+      done
+    else
+      show_all_status
+    fi
+    ;;
+  waiting)
+    # waiting subcommand processing
+    wt_num=$(get_current_worktree_num)
+
+    if [[ -z "$wt_num" ]]; then
+      echo "❌ Not in a git-wt managed worktree"
+      exit 1
+    fi
+
+    mark_worktree_waiting "$wt_num"
+    echo "⏳ Marked as waiting for input (worktree $wt_num)"
+    ;;
+  asking)
+    # asking subcommand processing
+    wt_num=$(get_current_worktree_num)
+
+    if [[ -z "$wt_num" ]]; then
+      echo "❌ Not in a git-wt managed worktree"
+      exit 1
+    fi
+
+    mark_worktree_asking "$wt_num"
+    echo "🙋 Marked as asking for selection (worktree $wt_num)"
+    ;;
+  claude-msg)
+    shift
+    # claude-msg subcommand processing (internal use by hooks)
+    msg="${1-}"
+    wt_num=$(get_current_worktree_num)
+
+    if [[ -z "$wt_num" ]]; then
+      exit 0  # Silent exit if not in worktree
+    fi
+
+    if [[ -n "$msg" ]]; then
+      set_worktree_claude_msg "$wt_num" "$msg"
     fi
     ;;
   "")

--- a/git-wt
+++ b/git-wt
@@ -1033,6 +1033,31 @@ case "$command" in
       set_worktree_claude_msg "$wt_num" "$msg"
     fi
     ;;
+  first-task)
+    shift
+    # first-task subcommand processing (internal use by hooks)
+    # Sets first_task directly, overwriting any existing value
+    task_desc="${1-}"
+    wt_num=$(get_current_worktree_num)
+
+    if [[ -z "$wt_num" ]]; then
+      exit 0  # Silent exit if not in worktree
+    fi
+
+    if [[ -n "$task_desc" ]]; then
+      status_dir=$(get_status_dir)
+      status_file="$status_dir/${wt_num}.json"
+
+      if [[ -f "$status_file" ]]; then
+        # Update first_task directly
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+          sed -i '' "s/\"first_task\": *\"[^\"]*\"/\"first_task\": \"$task_desc\"/" "$status_file"
+        else
+          sed -i "s/\"first_task\": *\"[^\"]*\"/\"first_task\": \"$task_desc\"/" "$status_file"
+        fi
+      fi
+    fi
+    ;;
   "")
     # No arguments: show selection menu
     echo "📋 Current worktrees:"

--- a/git-wt-hook
+++ b/git-wt-hook
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# git-wt-hook - Claude Code hook script for git-wt task tracking
+# This script is called by Claude Code's UserPromptSubmit hook
+# Input: JSON via stdin with user prompt
+set -euo pipefail
+
+# Check if current directory is a git-wt managed worktree
+is_git_wt_worktree() {
+  [[ "$PWD" =~ \.worktrees/[1-9](/|$) ]]
+}
+
+# Exit silently if not in a git-wt worktree
+if ! is_git_wt_worktree; then
+  exit 0
+fi
+
+# Read JSON input from stdin
+input=$(cat)
+
+# Extract prompt from JSON (works with Claude Code's hook format)
+# Format: {"session_id": "...", "prompt": "user message here"}
+prompt=""
+if command -v jq &>/dev/null; then
+  prompt=$(echo "$input" | jq -r '.prompt // empty' 2>/dev/null) || true
+else
+  # Fallback: extract prompt using grep/sed (basic parsing)
+  prompt=$(echo "$input" | grep -o '"prompt": *"[^"]*"' | sed 's/"prompt": *"\(.*\)"/\1/' | head -1) || true
+fi
+
+# Exit if no prompt found
+[[ -z "$prompt" ]] && exit 0
+
+# Truncate prompt to first 50 characters for task description
+task_desc="${prompt:0:50}"
+# Add ellipsis if truncated
+[[ ${#prompt} -gt 50 ]] && task_desc="${task_desc}..."
+
+# Find git-wt command
+GIT_WT=""
+if command -v git-wt &>/dev/null; then
+  GIT_WT="git-wt"
+elif [[ -x "$HOME/bin/git-wt" ]]; then
+  GIT_WT="$HOME/bin/git-wt"
+elif [[ -x "$HOME/CircleAround/bin/git-wt" ]]; then
+  GIT_WT="$HOME/CircleAround/bin/git-wt"
+fi
+
+# Set task if git-wt is available
+if [[ -n "$GIT_WT" ]]; then
+  "$GIT_WT" task "$task_desc" >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/git-wt-hook-pretool
+++ b/git-wt-hook-pretool
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# git-wt-hook-pretool - Claude Code PreToolUse hook for git-wt
+# Mark as waiting when tools that may require permission are about to be used
+set -euo pipefail
+
+# Check if current directory is a git-wt managed worktree
+is_git_wt_worktree() {
+  [[ "$PWD" =~ \.worktrees/[1-9](/|$) ]]
+}
+
+# Exit silently if not in a git-wt worktree
+if ! is_git_wt_worktree; then
+  exit 0
+fi
+
+# Read JSON input from stdin
+input=$(cat)
+
+# Extract tool_name from JSON
+tool_name=""
+if command -v jq &>/dev/null; then
+  tool_name=$(echo "$input" | jq -r '.tool_name // empty' 2>/dev/null) || true
+else
+  tool_name=$(echo "$input" | grep -o '"tool_name": *"[^"]*"' | sed 's/"tool_name": *"\(.*\)"/\1/' | head -1) || true
+fi
+
+# Tools that may require permission (user interaction)
+case "$tool_name" in
+  Bash|Edit|Write|NotebookEdit)
+    # These tools may show permission dialog
+    ;;
+  *)
+    # Other tools typically auto-execute
+    exit 0
+    ;;
+esac
+
+# Find git-wt command
+GIT_WT=""
+if command -v git-wt &>/dev/null; then
+  GIT_WT="git-wt"
+elif [[ -x "$HOME/bin/git-wt" ]]; then
+  GIT_WT="$HOME/bin/git-wt"
+elif [[ -x "$HOME/CircleAround/bin/git-wt" ]]; then
+  GIT_WT="$HOME/CircleAround/bin/git-wt"
+fi
+
+# Mark as waiting (may be waiting for permission)
+if [[ -n "$GIT_WT" ]]; then
+  "$GIT_WT" waiting >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/git-wt-hook-stop
+++ b/git-wt-hook-stop
@@ -39,22 +39,26 @@ fi
 # Mark as waiting
 "$GIT_WT" waiting >/dev/null 2>&1 || true
 
-# Extract Claude's last message from transcript
+# Extract messages from transcript
 if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
-  claude_message=""
   if command -v jq &>/dev/null; then
+    # Extract first user message for first_task (full text, first line only)
+    first_user_msg=$(grep '"type":"user"' "$transcript_path" 2>/dev/null | head -1 | jq -r '.message.content[0].text // empty' 2>/dev/null) || true
+    if [[ -n "$first_user_msg" ]]; then
+      # Get first line only
+      first_line=$(echo "$first_user_msg" | head -1)
+      "$GIT_WT" first-task "$first_line" >/dev/null 2>&1 || true
+    fi
+
+    # Extract Claude's last message
     claude_message=$(grep '"type":"assistant"' "$transcript_path" 2>/dev/null | tail -1 | jq -r '.message.content[0].text // empty' 2>/dev/null) || true
-  fi
-
-  # Save Claude's message if found (truncate to first line, max 100 chars)
-  if [[ -n "$claude_message" ]]; then
-    # Get first line only
-    first_line=$(echo "$claude_message" | head -1)
-    # Truncate to 100 chars
-    truncated="${first_line:0:100}"
-    [[ ${#first_line} -gt 100 ]] && truncated="${truncated}..."
-
-    "$GIT_WT" claude-msg "$truncated" >/dev/null 2>&1 || true
+    if [[ -n "$claude_message" ]]; then
+      # Get first line only, truncate to 100 chars
+      first_line=$(echo "$claude_message" | head -1)
+      truncated="${first_line:0:100}"
+      [[ ${#first_line} -gt 100 ]] && truncated="${truncated}..."
+      "$GIT_WT" claude-msg "$truncated" >/dev/null 2>&1 || true
+    fi
   fi
 fi
 

--- a/git-wt-hook-stop
+++ b/git-wt-hook-stop
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# git-wt-hook-stop - Claude Code Stop hook for git-wt
+# Called when Claude finishes responding (waiting for user input)
+set -euo pipefail
+
+# Check if current directory is a git-wt managed worktree
+is_git_wt_worktree() {
+  [[ "$PWD" =~ \.worktrees/[1-9](/|$) ]]
+}
+
+# Exit silently if not in a git-wt worktree
+if ! is_git_wt_worktree; then
+  exit 0
+fi
+
+# Read JSON input from stdin
+input=$(cat)
+
+# Extract transcript_path from JSON
+transcript_path=""
+if command -v jq &>/dev/null; then
+  transcript_path=$(echo "$input" | jq -r '.transcript_path // empty' 2>/dev/null) || true
+else
+  transcript_path=$(echo "$input" | grep -o '"transcript_path": *"[^"]*"' | sed 's/"transcript_path": *"\(.*\)"/\1/' | head -1) || true
+fi
+
+# Find git-wt command
+GIT_WT=""
+if command -v git-wt &>/dev/null; then
+  GIT_WT="git-wt"
+elif [[ -x "$HOME/bin/git-wt" ]]; then
+  GIT_WT="$HOME/bin/git-wt"
+elif [[ -x "$HOME/CircleAround/bin/git-wt" ]]; then
+  GIT_WT="$HOME/CircleAround/bin/git-wt"
+fi
+
+[[ -z "$GIT_WT" ]] && exit 0
+
+# Mark as waiting
+"$GIT_WT" waiting >/dev/null 2>&1 || true
+
+# Extract Claude's last message from transcript
+if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
+  claude_message=""
+  if command -v jq &>/dev/null; then
+    claude_message=$(grep '"type":"assistant"' "$transcript_path" 2>/dev/null | tail -1 | jq -r '.message.content[0].text // empty' 2>/dev/null) || true
+  fi
+
+  # Save Claude's message if found (truncate to first line, max 100 chars)
+  if [[ -n "$claude_message" ]]; then
+    # Get first line only
+    first_line=$(echo "$claude_message" | head -1)
+    # Truncate to 100 chars
+    truncated="${first_line:0:100}"
+    [[ ${#first_line} -gt 100 ]] && truncated="${truncated}..."
+
+    "$GIT_WT" claude-msg "$truncated" >/dev/null 2>&1 || true
+  fi
+fi
+
+exit 0

--- a/git-wt-hook-tool
+++ b/git-wt-hook-tool
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# git-wt-hook-tool - Claude Code PostToolUse hook for git-wt
+# - AskUserQuestion → asking (選択待ち)
+# - Other tools → active (作業継続)
+set -euo pipefail
+
+# Check if current directory is a git-wt managed worktree
+is_git_wt_worktree() {
+  [[ "$PWD" =~ \.worktrees/[1-9](/|$) ]]
+}
+
+# Exit silently if not in a git-wt worktree
+if ! is_git_wt_worktree; then
+  exit 0
+fi
+
+# Read JSON input from stdin
+input=$(cat)
+
+# Extract tool_name from JSON
+tool_name=""
+if command -v jq &>/dev/null; then
+  tool_name=$(echo "$input" | jq -r '.tool_name // empty' 2>/dev/null) || true
+else
+  # Fallback: extract using grep/sed
+  tool_name=$(echo "$input" | grep -o '"tool_name": *"[^"]*"' | sed 's/"tool_name": *"\(.*\)"/\1/' | head -1) || true
+fi
+
+# Find git-wt command
+GIT_WT=""
+if command -v git-wt &>/dev/null; then
+  GIT_WT="git-wt"
+elif [[ -x "$HOME/bin/git-wt" ]]; then
+  GIT_WT="$HOME/bin/git-wt"
+elif [[ -x "$HOME/CircleAround/bin/git-wt" ]]; then
+  GIT_WT="$HOME/CircleAround/bin/git-wt"
+fi
+
+[[ -z "$GIT_WT" ]] && exit 0
+
+# AskUserQuestion → asking (選択待ち)
+# Other permission-required tools → active (許可されて作業継続)
+case "$tool_name" in
+  AskUserQuestion)
+    "$GIT_WT" asking >/dev/null 2>&1 || true
+    ;;
+  Bash|Edit|Write|NotebookEdit)
+    # These were set to waiting in PreToolUse, now back to active
+    current_task=$("$GIT_WT" task 2>/dev/null | grep -o ': .*' | sed 's/^: //' || echo "")
+    if [[ -n "$current_task" && "$current_task" != "(no task set)" && "$current_task" != "(タスクなし)" ]]; then
+      "$GIT_WT" task "$current_task" >/dev/null 2>&1 || true
+    fi
+    ;;
+esac
+
+exit 0

--- a/git-wt-web
+++ b/git-wt-web
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# git-wt-web - Launch web UI for git-wt status monitoring
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Check if node is available
+if ! command -v node &>/dev/null; then
+  echo "Error: Node.js is required but not installed" >&2
+  exit 1
+fi
+
+# Check if in git repository
+if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+  echo "Error: Not a git repository" >&2
+  exit 1
+fi
+
+# Run the Node.js server
+exec node "$SCRIPT_DIR/git-wt-web.js" "$@"

--- a/git-wt-web.js
+++ b/git-wt-web.js
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+// git-wt-web.js - Web UI for git-wt status monitoring
+
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const PORT = process.env.PORT || 3456;
+
+// Get repository info from git
+function getRepoInfo() {
+  try {
+    const root = execSync('git worktree list | head -n1 | awk \'{print $1}\'', { encoding: 'utf8' }).trim();
+    const repo = path.basename(root);
+    const wroot = path.join(path.dirname(root), `${repo}.worktrees`);
+    return { root, repo, wroot };
+  } catch (e) {
+    return null;
+  }
+}
+
+// Get worktree info
+function getWorktreeInfo(wroot, num) {
+  const worktreePath = path.join(wroot, String(num));
+  if (!fs.existsSync(worktreePath)) return null;
+
+  let branch = '-';
+  try {
+    branch = execSync(`git -C "${worktreePath}" rev-parse --abbrev-ref HEAD`, { encoding: 'utf8' }).trim();
+  } catch (e) {}
+
+  return { path: worktreePath, branch };
+}
+
+// Read status file
+function readStatus(wroot, num) {
+  const statusFile = path.join(wroot, '.status', `${num}.json`);
+  if (!fs.existsSync(statusFile)) return null;
+
+  try {
+    return JSON.parse(fs.readFileSync(statusFile, 'utf8'));
+  } catch (e) {
+    return null;
+  }
+}
+
+// Format relative time
+function formatRelativeTime(timestamp) {
+  if (!timestamp) return '';
+  const then = new Date(timestamp.replace(' ', 'T'));
+  const now = new Date();
+  const diff = Math.floor((now - then) / 1000);
+
+  if (diff < 60) return 'now';
+  if (diff < 3600) return `${Math.floor(diff / 60)}分前`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}時間前`;
+  return `${Math.floor(diff / 86400)}日前`;
+}
+
+// Get status icon and label
+function getStatusDisplay(status) {
+  switch (status) {
+    case 'asking': return { icon: '🙋', label: '選択待ち', class: 'asking' };
+    case 'waiting': return { icon: '⏳', label: '入力待ち', class: 'waiting' };
+    case 'active': return { icon: '●', label: '作業中', class: 'active' };
+    case 'done': return { icon: '✓', label: '完了', class: 'done' };
+    default: return { icon: '', label: '', class: '' };
+  }
+}
+
+// Generate HTML
+function generateHTML(repoInfo) {
+  const { root, repo, wroot } = repoInfo;
+
+  let mainBranch = '-';
+  try {
+    mainBranch = execSync(`git -C "${root}" rev-parse --abbrev-ref HEAD`, { encoding: 'utf8' }).trim();
+  } catch (e) {}
+
+  let worktreesHTML = '';
+
+  // Main repo
+  worktreesHTML += `
+    <div class="worktree main">
+      <div class="header">
+        <span class="num">[0]</span>
+        <span class="branch">${mainBranch}</span>
+        <span class="label">(main)</span>
+      </div>
+    </div>
+  `;
+
+  // Worktrees 1-9
+  for (let num = 1; num <= 9; num++) {
+    const wtInfo = getWorktreeInfo(wroot, num);
+    if (!wtInfo) continue;
+
+    const status = readStatus(wroot, num) || {};
+    const statusDisplay = getStatusDisplay(status.status);
+    const relativeTime = formatRelativeTime(status.updated);
+
+    worktreesHTML += `
+    <div class="worktree ${statusDisplay.class}">
+      <div class="header">
+        <span class="num">[${num}]</span>
+        <span class="branch">${wtInfo.branch}</span>
+        ${statusDisplay.icon ? `<span class="status-badge ${statusDisplay.class}">${statusDisplay.icon} ${statusDisplay.label}</span>` : ''}
+        ${relativeTime ? `<span class="time">${relativeTime}</span>` : ''}
+      </div>
+      ${status.first_task ? `<div class="first-task"><span class="icon">📋</span> ${escapeHtml(status.first_task)}</div>` : ''}
+      ${status.last_task && status.last_task !== status.first_task ? `<div class="last-task"><span class="icon">└─</span> ${escapeHtml(status.last_task)}</div>` : ''}
+      ${status.claude_msg ? `<div class="claude-msg"><span class="icon">🤖</span> ${escapeHtml(status.claude_msg)}</div>` : ''}
+    </div>
+    `;
+  }
+
+  if (worktreesHTML.split('class="worktree"').length <= 2) {
+    worktreesHTML += '<div class="no-worktrees">(ワークツリーなし)</div>';
+  }
+
+  return `<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="refresh" content="2">
+  <title>git-wt status - ${repo}</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      background: #1a1a2e;
+      color: #eee;
+      padding: 20px;
+      min-height: 100vh;
+    }
+    h1 {
+      font-size: 1.5rem;
+      margin-bottom: 20px;
+      color: #888;
+      border-bottom: 1px solid #333;
+      padding-bottom: 10px;
+    }
+    h1 span { color: #4fc3f7; }
+    .worktree {
+      background: #16213e;
+      border-radius: 8px;
+      padding: 16px;
+      margin-bottom: 12px;
+      border-left: 4px solid #333;
+      transition: all 0.2s;
+    }
+    .worktree.main { border-left-color: #888; opacity: 0.7; }
+    .worktree.active { border-left-color: #4caf50; }
+    .worktree.waiting { border-left-color: #ff9800; }
+    .worktree.asking { border-left-color: #e91e63; }
+    .worktree.done { border-left-color: #2196f3; }
+    .header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .num {
+      font-weight: bold;
+      color: #888;
+      font-family: monospace;
+    }
+    .branch {
+      font-weight: bold;
+      color: #4fc3f7;
+      font-family: monospace;
+    }
+    .label { color: #666; font-size: 0.9rem; }
+    .status-badge {
+      font-size: 0.85rem;
+      padding: 2px 8px;
+      border-radius: 4px;
+      background: #333;
+    }
+    .status-badge.active { background: #1b5e20; color: #a5d6a7; }
+    .status-badge.waiting { background: #e65100; color: #ffcc80; }
+    .status-badge.asking { background: #880e4f; color: #f48fb1; }
+    .status-badge.done { background: #0d47a1; color: #90caf9; }
+    .time {
+      color: #666;
+      font-size: 0.85rem;
+      margin-left: auto;
+    }
+    .first-task, .last-task, .claude-msg {
+      margin-top: 8px;
+      padding-left: 24px;
+      font-size: 0.95rem;
+      line-height: 1.5;
+    }
+    .first-task { color: #fff; }
+    .last-task { color: #aaa; font-size: 0.9rem; }
+    .claude-msg { color: #81c784; font-size: 0.9rem; }
+    .icon { margin-right: 8px; }
+    .no-worktrees {
+      color: #666;
+      text-align: center;
+      padding: 40px;
+    }
+    .footer {
+      margin-top: 20px;
+      text-align: center;
+      color: #444;
+      font-size: 0.8rem;
+    }
+  </style>
+</head>
+<body>
+  <h1>git-wt status <span>${repo}</span></h1>
+  ${worktreesHTML}
+  <div class="footer">Auto-refresh: 2s | ${new Date().toLocaleTimeString('ja-JP')}</div>
+</body>
+</html>`;
+}
+
+function escapeHtml(text) {
+  if (!text) return '';
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// Start server
+const repoInfo = getRepoInfo();
+if (!repoInfo) {
+  console.error('Error: Not a git repository');
+  process.exit(1);
+}
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/' || req.url === '/index.html') {
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(generateHTML(repoInfo));
+  } else if (req.url === '/api/status') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    const statuses = {};
+    for (let num = 1; num <= 9; num++) {
+      const status = readStatus(repoInfo.wroot, num);
+      if (status) statuses[num] = status;
+    }
+    res.end(JSON.stringify(statuses));
+  } else {
+    res.writeHead(404);
+    res.end('Not Found');
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`git-wt web UI running at http://localhost:${PORT}`);
+  console.log(`Repository: ${repoInfo.repo}`);
+  console.log('Press Ctrl+C to stop');
+});


### PR DESCRIPTION
## Summary

- Add status tracking for git-wt worktrees with Claude Code hooks integration
- Extract first_task from transcript for session-based tracking
- Add Web UI for monitoring worktree status in browser

## Features

### Status Tracking
- `git-wt task [desc]` - Set/show task for current worktree
- `git-wt status [-w]` - Show all worktrees status (with watch mode)
- Automatic status updates via Claude Code hooks (UserPromptSubmit, Stop, PreToolUse, PostToolUse)
- Status types: active, waiting, asking

### Web UI
- `git-wt-web` - Launch browser-based status dashboard
- Auto-refresh every 2 seconds
- Dark theme with status-based color coding
- Shows first_task, last_task, and Claude's message

## New Files
- `git-wt-hook` - UserPromptSubmit hook
- `git-wt-hook-stop` - Stop hook (extracts Claude's message and first user message)
- `git-wt-hook-pretool` - PreToolUse hook
- `git-wt-hook-tool` - PostToolUse hook
- `git-wt-web` - Web UI launcher
- `git-wt-web.js` - Node.js server for Web UI

## Test plan
- [ ] Create multiple worktrees with `git-wt add`
- [ ] Run Claude Code in worktrees and verify status tracking
- [ ] Test `git-wt status` and `git-wt status -w`
- [ ] Test `git-wt-web` and verify browser display

🤖 Generated with [Claude Code](https://claude.com/claude-code)